### PR TITLE
padronização de não encontrado

### DIFF
--- a/src/resources/resources.service.ts
+++ b/src/resources/resources.service.ts
@@ -24,7 +24,7 @@ export class ResourcesService {
   async findOne(id: number): Promise<Resource> {
     const resource = await this.resourcesRepository.findOneBy({ id });
     if (!resource) {
-      throw new NotFoundException(`Recurso com ID ${id} não encontrado.`);
+      throw new NotFoundException(`Recurso com ID ${id} não encontrado(a).`);
     }
     return resource;
   }
@@ -38,7 +38,7 @@ export class ResourcesService {
   async remove(id: number): Promise<void> {
     const result = await this.resourcesRepository.delete(id);
     if (result.affected === 0) {
-      throw new NotFoundException(`Recurso com ID ${id} não encontrado.`);
+      throw new NotFoundException(`Recurso com ID ${id} não encontrado(a).`);
     }
   }
 }

--- a/src/rooms/rooms.service.ts
+++ b/src/rooms/rooms.service.ts
@@ -71,7 +71,8 @@ export class RoomsService {
       ...updateRoomDto,
     });
     if (!room) {
-      throw new NotFoundException(`Sala com ID ${id} não encontrada.`);
+      // Mensagem padronizada
+      throw new NotFoundException(`Sala com ID ${id} não encontrado(a).`);
     }
     // Não permitir reativar uma sala desativada por este método
     if (room.status === RoomStatus.DEACTIVATED && updateRoomDto.status !== RoomStatus.DEACTIVATED) {
@@ -97,6 +98,7 @@ export class RoomsService {
 
   async addResourceToRoom(roomId: number, resourceId: number): Promise<Room> {
     const room = await this.findOne(roomId); // Busca a sala, já carregando os recursos atuais
+    // resourcesService.findOne agora lança a exceção padronizada se não encontrar o recurso.
     const resource = await this.resourcesService.findOne(resourceId); // Busca o recurso
 
     // Verifica se o recurso já está na sala para evitar duplicatas


### PR DESCRIPTION
Esta Pull Request padroniza as mensagens de erro NotFoundException nos serviços principais (UsersService, ResourcesService, e RoomsService) conforme definido na Issue #17.
A padronização adota o formato: "{Entidade} com ID {id} não encontrado(a).".