### PR TITLE
Colocando o jwt na parte externa do codigo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# .env.example
+JWT_SECRET='SEU_SEGREDO_SUPER_SECRETO'

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@nestjs/axios": "^4.0.1",
+        "@nestjs/config": "^4.0.2",
         "@nestjs/jwt": "^11.0.1",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.1.6",
@@ -2069,6 +2070,33 @@
         "class-validator": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/config": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-4.0.2.tgz",
+      "integrity": "sha512-McMW6EXtpc8+CwTUwFdg6h7dYcBUpH5iUILCclAsa+MbCEvC9ZKu4dCHRlJqALuhjLw97pbQu62l4+wRwGeZqA==",
+      "license": "MIT",
+      "dependencies": {
+        "dotenv": "16.4.7",
+        "dotenv-expand": "12.0.1",
+        "lodash": "4.17.21"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "rxjs": "^7.1.0"
+      }
+    },
+    "node_modules/@nestjs/config/node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/@nestjs/core": {
@@ -5353,6 +5381,21 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
       "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
       "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-12.0.1.tgz",
+      "integrity": "sha512-LaKRbou8gt0RNID/9RoI+J2rvXsBRPMV7p+ElHlPhcSARbCPDYcYG2s1TIzAfWv4YSgyY5taidWzzs31lNV3yQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "homepage": "https://github.com/lucasfbegnini/Sistema-de-reserva#readme",
   "dependencies": {
     "@nestjs/axios": "^4.0.1",
+    "@nestjs/config": "^4.0.2",
     "@nestjs/jwt": "^11.0.1",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.1.6",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,20 +1,24 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config'; // Importar ConfigModule
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { HealthModule } from './health/health.module';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UsersModule } from './users/users.module';
 import { User } from './users/entities/user.entity';
-import { AuthModule } from './auth/auth.module'; 
+import { AuthModule } from './auth/auth.module';
 import { APP_GUARD } from '@nestjs/core';
 import { JwtAuthGuard } from './auth/jwt-auth.guard';
 import { RoomsModule } from './rooms/rooms.module';
 import { ResourcesModule } from './resources/resources.module';
-import { Room } from './rooms/entities/room.entity'; 
-import { Resource } from './resources/entities/resource.entity'; 
+import { Room } from './rooms/entities/room.entity';
+import { Resource } from './resources/entities/resource.entity';
 
 @Module({
   imports: [
+    ConfigModule.forRoot({ // Adicionar ConfigModule
+      isGlobal: true, // Tornar as variáveis de ambiente disponíveis globalmente
+    }),
     HealthModule,
     TypeOrmModule.forRoot({
       type: 'sqlite',
@@ -25,12 +29,12 @@ import { Resource } from './resources/entities/resource.entity';
     UsersModule,
     AuthModule,
     RoomsModule,
-    ResourcesModule, 
+    ResourcesModule,
   ],
   controllers: [AppController],
   providers: [
     AppService,
-    { 
+    {
       provide: APP_GUARD,
       useClass: JwtAuthGuard,
     },

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,18 +1,23 @@
 import { Module } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
-import { UsersModule } from '../users/users.module'; 
+import { UsersModule } from '../users/users.module';
 import { PassportModule } from '@nestjs/passport';
 import { JwtModule } from '@nestjs/jwt';
 import { JwtStrategy } from './jwt.strategy';
+import { ConfigModule, ConfigService } from '@nestjs/config'; // Importar ConfigModule e ConfigService
 
 @Module({
   imports: [
-    UsersModule, 
+    UsersModule,
     PassportModule,
-    JwtModule.register({
-      secret: 'SEU_SEGREDO_SUPER_SECRETO',
-      signOptions: { expiresIn: '60m' }, 
+    JwtModule.registerAsync({ // Mudar para registerAsync
+      imports: [ConfigModule], // Importar ConfigModule aqui também
+      useFactory: async (configService: ConfigService) => ({
+        secret: configService.get<string>('JWT_SECRET'), // Buscar o segredo do .env
+        signOptions: { expiresIn: '60m' },
+      }),
+      inject: [ConfigService], // Injetar ConfigService
     }),
   ],
   controllers: [AuthController],


### PR DESCRIPTION
Consertando issue #14 

Refatora: Move segredo JWT para variável de ambiente

- Instala e configura o @nestjs/config.
- Atualiza AuthModule e JwtStrategy para usar ConfigService.
- Remove o segredo JWT fixo do código-fonte.
- Adiciona .env.example para documentar a variável necessária.